### PR TITLE
CASMHMS-5458 Coordination for HMS CT Helm tests

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -1,9 +1,15 @@
 # Changelog for v2.1
 
-All notable changes to this project for v2.0.Z will be documented in this file.
+All notable changes to this project for v2.1.Z will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.3] - 2022-06-22
+
+### Changed
+
+- updated CT tests to hms-test:3.1.0 image as part of Helm test coordination
 
 ## [2.1.2] - 2022-06-07
 

--- a/charts/v2.1/cray-hms-firmware-action/Chart.yaml
+++ b/charts/v2.1/cray-hms-firmware-action/Chart.yaml
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.19.0"
+appVersion: "1.20.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-firmware-action/values.yaml
+++ b/charts/v2.1/cray-hms-firmware-action/values.yaml
@@ -8,19 +8,21 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.19.0
-  testVersion: 1.19.0
+  appVersion: 1.20.0
+  testVersion: 1.20.0
+
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-firmware-action
   pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-firmware-action-test
+    pullPolicy: IfNotPresent
+
 nexus:
   endpoint: http://nexus.nexus.svc.cluster.local
   repo: shasta-firmware
-tests:
-  image:
-    #repository: artifactory.algol60.net/csm-docker/stable/cray-firmware-action-test
-    repository: artifactory.algol60.net/csm-docker/unstable/cray-firmware-action-test
-    pullPolicy: Always
 
 hms_ca_uri: ""
 cray-service:

--- a/cray-hms-firmware-action.compatibility.yaml
+++ b/cray-hms-firmware-action.compatibility.yaml
@@ -18,6 +18,7 @@ chartVersionToApplicationVersion:
   "2.1.0": "1.18.0"
   "2.1.1": "1.19.0"
   "2.1.2": "1.19.0"
+  "2.1.3": "1.20.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

- Update CT tests to stable hms-test:3.1.0 image (upgrades pytest and tavern to work around python issue43798)
- Pull Alpine base image from correct location in algol60 artifactory
- CT test cleanup

### Issues and Related PRs

* Partially resolves CASMHMS-5458.

### Testing

This change was tested by deploying the updated version of the service and chart onto Mug, executing the Helm CT tests, and verifying that they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, test update.