### PR TITLE
CASMHMS-5646 Update FAS for arti.dev.cray.com domain retirement

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,14 @@ All notable changes to this project for v2.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.5] - 2022-08-04
+
+### Changed
+
+- Updated to stable, nightly algol60 images
+- Updated Alpine base image version
+- Removed unused integration test Pipfile and Dockerfiles
+
 ## [2.1.4] - 2022-07-20
 
 ### Changed

--- a/charts/v2.1/cray-hms-firmware-action/Chart.yaml
+++ b/charts/v2.1/cray-hms-firmware-action/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-firmware-action"
-version: 2.1.4
+version: 2.1.5
 description: "Kubernetes resources for cray-hms-firmware-action"
 home: "https://github.com/Cray-HPE/hms-firmware-action-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.22.0"
+appVersion: "1.23.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-firmware-action/values.yaml
+++ b/charts/v2.1/cray-hms-firmware-action/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.22.0
-  testVersion: 1.22.0
+  appVersion: 1.23.0
+  testVersion: 1.23.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-firmware-action

--- a/cray-hms-firmware-action.compatibility.yaml
+++ b/cray-hms-firmware-action.compatibility.yaml
@@ -20,6 +20,7 @@ chartVersionToApplicationVersion:
   "2.1.2": "1.19.0"
   "2.1.3": "1.20.0"
   "2.1.4": "1.22.0"
+  "2.1.5": "1.23.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

- Removed unused integration test Pipfile and Dockerfiles (contained reference to arti.dev.cray.com)
- Updated to stable, nightly algol60 images.
- Updated Alpine base image version.

### Issues and Related PRs

* Resolves [CASMHMS-5646](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5646).

### Testing

This change was tested by building and running the FAS unit, integration, and CT tests and verifying that they continued to pass.

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.