### PR TITLE
CASMHMS-5840 Update FAS actions test to improve handling of unexpected BMC states

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,13 @@ All notable changes to this project for v2.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.6] - 2022-11-23
+
+### Changed
+
+- Updated FAS actions test to better handle powered off BMCs
+- Updated FAS CT tests to use hms-test:4.0.0 image for HMTH
+
 ## [2.1.5] - 2022-08-04
 
 ### Changed

--- a/charts/v2.1/cray-hms-firmware-action/Chart.yaml
+++ b/charts/v2.1/cray-hms-firmware-action/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-firmware-action"
-version: 2.1.5
+version: 2.1.6
 description: "Kubernetes resources for cray-hms-firmware-action"
 home: "https://github.com/Cray-HPE/hms-firmware-action-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.23.0"
+appVersion: "1.24.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-firmware-action/templates/tests/test-functional.yaml
+++ b/charts/v2.1/cray-hms-firmware-action/templates/tests/test-functional.yaml
@@ -33,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: [ "entrypoint.sh functional -c /src/libs/tavern_global_config.yaml -p /src/app"]
+          args: ["entrypoint.sh tavern -c /src/libs/tavern_global_config.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v2.1/cray-hms-firmware-action/templates/tests/test-smoke.yaml
+++ b/charts/v2.1/cray-hms-firmware-action/templates/tests/test-smoke.yaml
@@ -33,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: [ "entrypoint.sh smoke -f smoke.json -u http://cray-fas"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-fas"]

--- a/charts/v2.1/cray-hms-firmware-action/values.yaml
+++ b/charts/v2.1/cray-hms-firmware-action/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.23.0
-  testVersion: 1.23.0
+  appVersion: 1.24.0
+  testVersion: 1.24.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-firmware-action
@@ -17,7 +17,7 @@ image:
 
 tests:
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/cray-firmware-action-test
+    repository: artifactory.algol60.net/csm-docker/stable/cray-firmware-action-hmth-test
     pullPolicy: IfNotPresent
 
 nexus:

--- a/cray-hms-firmware-action.compatibility.yaml
+++ b/cray-hms-firmware-action.compatibility.yaml
@@ -21,6 +21,7 @@ chartVersionToApplicationVersion:
   "2.1.3": "1.20.0"
   "2.1.4": "1.22.0"
   "2.1.5": "1.23.0"
+  "2.1.6": "1.24.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This change updates the FAS actions test to better handle unexpected BMC states. Previously the test would fail if there was at least one BMC in HSM with an unexpected state. This case is covered by a separate HSM test, so now the FAS actions test will not fail in this scenario and only requires the minimum of one healthy BMC to run.

This change also updates the FAS CT tests to use the latest hms-test:4.0.0 image and RIE.

### Issues and Related PRs

* Resolves CASMHMS-5840.

### Testing

This change was tested by verifying that the FAS tests continue to pass in the runCT build environment using RIE emulated hardware. It was also tested on Frigg by upgrading FAS to the new 2.1.6 version of the chart, running the FAS CT tests, and verifying that they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? Y

### Risks and Mitigations

Low risk, makes FAS actions test more resilient. The other changes only impact FAS testing in the CT build pipeline.