### PR TITLE
CASMTRIAGE-5392 Add disasterRecovery section

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -5,8 +5,14 @@ All notable changes to this project for v3.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2023-05-18
+
+### Added
+
+- Added disasterRecovery section to chart
+
 ## [3.0.0] - 2023-03-20
 
-### changed
+### Changed
 
 - upgraded ETCD operator

--- a/charts/v3.0/cray-hms-firmware-action/Chart.yaml
+++ b/charts/v3.0/cray-hms-firmware-action/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-firmware-action"
-version: 3.0.0
+version: 3.0.1
 description: "Kubernetes resources for cray-hms-firmware-action"
 home: "https://github.com/Cray-HPE/hms-firmware-action-charts"
 sources:

--- a/charts/v3.0/cray-hms-firmware-action/values.yaml
+++ b/charts/v3.0/cray-hms-firmware-action/values.yaml
@@ -33,6 +33,12 @@ cray-etcd-base:
     enabled: true
     fullnameOverride: "cray-fas-bitnami-etcd"
     nameOverride: "cray-fas-bitnami-etcd"
+    disasterRecovery:
+      cronjob:
+        snapshotsDir: "/snapshots/cray-fas-bitnami-etcd"
+        schedule: "0 */1 * * *"
+        historyLimit: 1
+        snapshotHistoryLimit: 24
     extraEnvVars:
       - name: ETCD_HEARTBEAT_INTERVAL
         value: "4200"

--- a/cray-hms-firmware-action.compatibility.yaml
+++ b/cray-hms-firmware-action.compatibility.yaml
@@ -24,6 +24,7 @@ chartVersionToApplicationVersion:
   "2.1.5": "1.23.0"
   "2.1.6": "1.24.0"
   "3.0.0": "1.27.0"
+  "3.0.1": "1.27.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Add required disasterRecovery chart section to allow for ETCD backups.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5392](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5392)

## Testing

Tested on:

  * `drax`

Test description:

Copied chart to drax and initiated a helm upgrade. Verified deployed chart contained the expected changes.

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable