### PR TITLE
FAS to version 1.34.0

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,14 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.7] - 2024-09-12
+
+### Changed
+
+- FAS to version 1.34.0
+- Add "Days to keep actions" to 60 days
+  - Auto remove actions after 60 days 
+
 ## [3.1.6] - 2024-08-30
 
 ### Changed

--- a/charts/v3.1/cray-hms-firmware-action/Chart.yaml
+++ b/charts/v3.1/cray-hms-firmware-action/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-firmware-action"
-version: 3.1.6
+version: 3.1.7
 description: "Kubernetes resources for cray-hms-firmware-action"
 home: "https://github.com/Cray-HPE/hms-firmware-action-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.33.0"
+appVersion: "1.34.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-firmware-action/values.yaml
+++ b/charts/v3.1/cray-hms-firmware-action/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.33.0
-  testVersion: 1.33.0
+  appVersion: 1.34.0
+  testVersion: 1.34.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-firmware-action
@@ -120,6 +120,8 @@ cray-service:
           value: "SERVICE"
         - name: TFTP_ENDPOINT
           value: tftp://cray-tftp.hmnlb.local
+        - name: DAYS_TO_KEEP_ACTIONS
+          value: 60
         - name: S3_ENDPOINT
           valueFrom:
             secretKeyRef:

--- a/cray-hms-firmware-action.compatibility.yaml
+++ b/cray-hms-firmware-action.compatibility.yaml
@@ -47,6 +47,7 @@ chartVersionToApplicationVersion:
   "3.1.4": "1.33.0"
   "3.1.5": "1.33.0"
   "3.1.6": "1.33.0"
+  "3.1.7": "1.34.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

- FAS to version 1.34.0
- Add "Days to keep actions" to 60 days
  - Auto remove actions after 60 days 


## Issues and Related PRs

- CASMHMS-6259