### PR TITLE
Added quotes around Days_to_keep_actions

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,10 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.8] - 2024-09-17
+
+- Added quotes around 60 days value
+
 ## [3.1.7] - 2024-09-12
 
 ### Changed

--- a/charts/v3.1/cray-hms-firmware-action/Chart.yaml
+++ b/charts/v3.1/cray-hms-firmware-action/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-firmware-action"
-version: 3.1.7
+version: 3.1.8
 description: "Kubernetes resources for cray-hms-firmware-action"
 home: "https://github.com/Cray-HPE/hms-firmware-action-charts"
 sources:

--- a/cray-hms-firmware-action.compatibility.yaml
+++ b/cray-hms-firmware-action.compatibility.yaml
@@ -48,6 +48,7 @@ chartVersionToApplicationVersion:
   "3.1.5": "1.33.0"
   "3.1.6": "1.33.0"
   "3.1.7": "1.34.0"
+  "3.1.8": "1.34.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Env varialbe "DAYS_TO_KEEP_ACTION" did not have quotes around the value (60) - that was updated with a accidental direct push to main.
This updates the version to 3.1.8 to create new charts.

## Issues and Related PRs

- CASMHMS-6259