### PR TITLE
CASMHMS-6282: Update Alpine base image to resolve CVE

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,10 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.11] - 2024-11-18
+
+- Update alpine base image to resolve CVE
+
 ## [3.1.10] - 2024-12-06
 
 ## Fixed

--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.11] - 2024-11-18
 
-- Update alpine base image to resolve CVE
+- Update Alpine base image to resolve CVE
+- New Alpine base image implemented PEP 668 which required switching to a
+  virtual python environment in our dockerfiles
+- Broke up RUN directive in dockerfiles for easier reading
+- Remove obsolete version field from docker-compose files
 
 ## [3.1.10] - 2024-12-06
 

--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.11] - 2024-11-18
 
+### Changed
+
 - Update Alpine base image to resolve CVE
 - New Alpine base image implemented PEP 668 which required switching to a
   virtual python environment in our dockerfiles
@@ -15,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.10] - 2024-12-06
 
-## Fixed
+### Fixed
 
 - Resolved various scaling/resource issues
 - Update to latest TRS

--- a/charts/v3.1/cray-hms-firmware-action/Chart.yaml
+++ b/charts/v3.1/cray-hms-firmware-action/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-firmware-action"
-version: 3.1.10
+version: 3.1.11
 description: "Kubernetes resources for cray-hms-firmware-action"
 home: "https://github.com/Cray-HPE/hms-firmware-action-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.35.0"
+appVersion: "1.36.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-firmware-action/values.yaml
+++ b/charts/v3.1/cray-hms-firmware-action/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.35.0
-  testVersion: 1.35.0
+  appVersion: 1.36.0
+  testVersion: 1.36.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-firmware-action

--- a/cray-hms-firmware-action.compatibility.yaml
+++ b/cray-hms-firmware-action.compatibility.yaml
@@ -51,6 +51,7 @@ chartVersionToApplicationVersion:
   "3.1.7": "1.34.0"
   "3.1.8": "1.34.0"
   "3.1.10": "1.35.0"
+  "3.1.11": "1.36.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated Alpine base image from 3.18 to 3.19 to resolve reported CVE's.  Decided not to use the latest Alpine image 3.21 as I didn't want to inject any more risk than necessary into CSM 1.6.1 just before the end of the release cycle.

Detailed changes include:

- Update Alpine base image to resolve CVE
- New Alpine base image implemented PEP 668 which required switching to a virtual python environment in our dockerfiles
- Broke up RUN directive in dockerfiles for easier reading
- Remove obsolete version field from docker-compose files

Adopted app version 1.36.0 for CSM 1.6.1 (helm chart 3.1.11)

### Issues and Related PRs

* Resolves [CASMHMS-6282](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6282)

### Testing

Tested on:

* `mug`

Test Description: 

Deployed on mug.  Ran functional tests and confirmed no failures.  Performed various FAS operations and confirmed no issues.  Watched FAS logs to ensure no errors reported.

Testing Check List:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable