### PR TITLE
CASMHMS-6324: Added support for ppprof builds

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,18 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.13] - 2025-01-08
+
+### Added
+
+- Added support for ppprof builds
+
+## [3.1.12] - 2024-12-20
+
+### Changed
+
+- Update to go libraries for security issues.
+
 ## [3.1.11] - 2024-11-18
 
 ### Changed

--- a/charts/v3.1/cray-hms-firmware-action/Chart.yaml
+++ b/charts/v3.1/cray-hms-firmware-action/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-firmware-action"
-version: 3.1.11
+version: 3.1.13
 description: "Kubernetes resources for cray-hms-firmware-action"
 home: "https://github.com/Cray-HPE/hms-firmware-action-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.36.0"
+appVersion: "1.38.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-firmware-action/values.yaml
+++ b/charts/v3.1/cray-hms-firmware-action/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.36.0
-  testVersion: 1.36.0
+  appVersion: 1.38.0
+  testVersion: 1.38.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-firmware-action

--- a/cray-hms-firmware-action.compatibility.yaml
+++ b/cray-hms-firmware-action.compatibility.yaml
@@ -52,6 +52,8 @@ chartVersionToApplicationVersion:
   "3.1.8": "1.34.0"
   "3.1.10": "1.35.0"
   "3.1.11": "1.36.0"
+  "3.1.12": "1.37.0"
+  "3.1.13": "1.38.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Added support for pprof builds.  Profiling adds runtime overhead so pprof support is not enabled by default.  It is meant to be a debug tool.  In order to enable pprof support, the following ARG in the Dockerfile should be changed from false to true:

    ARG ENABLE_PPROF=true

After completing this step, rebuild the application and pprof support will be enabled after it is deployed.

Adopted app version 2.7.0 for CSM 1.6.1 (helm chart 2.1.11)

## Issues and Related PRs

* Resolves [CASMHMS-6324](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6324)

## Testing

Tested on:

  * `mug`

Test description:

- Deployed service with pprof enabled - confirmed pprof functionality
- Deployed services with pprof disabled - confirmed pprof support not built into binary
- Functional tests (if they exist) was successfully ran with and without pprof enabled

Test Checklist:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable