### PR TITLE
CASMHMS-6410: Update module dependencies related to hms-certs

### DIFF
--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,6 +5,12 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - 2025-03-10
+
+### Security
+
+- Update module dependencies related to hms-certs
+
 ## [3.2.0] - 2025-01-29
 
 ### Security

--- a/charts/v3.2/cray-hms-firmware-action/Chart.yaml
+++ b/charts/v3.2/cray-hms-firmware-action/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-firmware-action"
-version: 3.2.0
+version: 3.2.1
 description: "Kubernetes resources for cray-hms-firmware-action"
 home: "https://github.com/Cray-HPE/hms-firmware-action-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.39.0"  # update pprof image version below as well
+appVersion: "1.40.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-hms-firmware-action-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-firmware-action-pprof:1.39.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-firmware-action-pprof:1.40.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.2/cray-hms-firmware-action/values.yaml
+++ b/charts/v3.2/cray-hms-firmware-action/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.39.0
-  testVersion: 1.39.0
+  appVersion: 1.40.0
+  testVersion: 1.40.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-firmware-action

--- a/cray-hms-firmware-action.compatibility.yaml
+++ b/cray-hms-firmware-action.compatibility.yaml
@@ -57,6 +57,7 @@ chartVersionToApplicationVersion:
   "3.1.12": "1.37.0"
   "3.1.13": "1.38.0"
   "3.2.0": "1.39.0"
+  "3.2.1": "1.40.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated module dependencies for security updates.  These were the ones related to hms-certs and vault.

The hms-certs update required changes to pass vault related override values to hms-certs.

Adopted app version 1.40.0 for CSM 1.7.0 (helm chart 3.2.1)

### Issues and Related PRs

* Resolves [CASMHMS-6410](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6410)

### Testing

Ran SMD smoke and integration tests on mug and watched logs for issues

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable