### PR TITLE
CASMHMS-6482: Update modules to pull in fixes to resource issues in HMS modules

### DIFF
--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,6 +5,17 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.2] - 2025-04-21
+
+### Update
+
+- Updated image and module dependencies to latest versions
+- Removed several sections of code that are now redundant with the latest
+  hms-base module
+- Update version of Go to v1.24
+- Fixed jq parsing issue when running local Snyk scans
+- Internal tracking ticket: CASMHMS-6482
+
 ## [3.2.1] - 2025-03-10
 
 ### Security

--- a/charts/v3.2/cray-hms-firmware-action/Chart.yaml
+++ b/charts/v3.2/cray-hms-firmware-action/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-firmware-action"
-version: 3.2.1
+version: 3.2.2
 description: "Kubernetes resources for cray-hms-firmware-action"
 home: "https://github.com/Cray-HPE/hms-firmware-action-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.40.0"  # update pprof image version below as well
+appVersion: "1.41.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-hms-firmware-action-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-firmware-action-pprof:1.40.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-firmware-action-pprof:1.41.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.2/cray-hms-firmware-action/values.yaml
+++ b/charts/v3.2/cray-hms-firmware-action/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.40.0
-  testVersion: 1.40.0
+  appVersion: 1.41.0
+  testVersion: 1.41.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-firmware-action

--- a/cray-hms-firmware-action.compatibility.yaml
+++ b/cray-hms-firmware-action.compatibility.yaml
@@ -58,6 +58,7 @@ chartVersionToApplicationVersion:
   "3.1.13": "1.38.0"
   "3.2.0": "1.39.0"
   "3.2.1": "1.40.0"
+  "3.2.2": "1.41.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the hms-base, hms-certs, hms-hmetcd, and hms-trs-app-api modules.

Several sections of FAS code were removed and/or replaced due to the most recent changes to hms-base.

Additionally upgraded Go from v1.23 to v1.24.  There were a number of code changes that were required to support differences in these two version of Go.

Fixed a jq parsing issue when running local Snyk scans.

Adopted app version 1.41.0 for CSM 1.7.0 (helm chart 3.2.2).

### Issues and Related PRs

* Resolves [CASMHMS-6482](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6482)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of FAS.  Watched log files to ensure nothing obvious was wrong.  Ran the standard FAS smoke and functional tests which all passed.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable