### PR TITLE
CASMTRIAGE-8151: Fix false positive test failure

### DIFF
--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,6 +5,13 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.3] - 2025-05-01
+
+### Fixed
+
+- Fix false positive test failure
+- Internal tracking ticket: CASMTRIAGE-8151
+
 ## [3.2.2] - 2025-04-21
 
 ### Update

--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.2.3] - 2025-05-01
+## [3.2.3] - 2025-04-29
 
 ### Fixed
 

--- a/charts/v3.2/cray-hms-firmware-action/Chart.yaml
+++ b/charts/v3.2/cray-hms-firmware-action/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-firmware-action"
-version: 3.2.2
+version: 3.2.3
 description: "Kubernetes resources for cray-hms-firmware-action"
 home: "https://github.com/Cray-HPE/hms-firmware-action-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.41.0"  # update pprof image version below as well
+appVersion: "1.42.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-hms-firmware-action-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-firmware-action-pprof:1.41.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-firmware-action-pprof:1.42.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.2/cray-hms-firmware-action/values.yaml
+++ b/charts/v3.2/cray-hms-firmware-action/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.41.0
-  testVersion: 1.41.0
+  appVersion: 1.42.0
+  testVersion: 1.42.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-firmware-action

--- a/cray-hms-firmware-action.compatibility.yaml
+++ b/cray-hms-firmware-action.compatibility.yaml
@@ -59,6 +59,7 @@ chartVersionToApplicationVersion:
   "3.2.0": "1.39.0"
   "3.2.1": "1.40.0"
   "3.2.2": "1.41.0"
+  "3.2.3": "1.42.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Fixed false positive test failure.

Adopted app version 1.42.0 for CSM 1.7.0 (helm chart 3.2.3).

### Issues and Related PRs

* Resolves [CASMTRIAGE-8151](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8151)

### Testing

Tested on:

* `tyr`

Test description:

Reran CT tests and observed the false positive no longer occurs.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable